### PR TITLE
Add MERGE support

### DIFF
--- a/lib/sequel/adapters/snowflake.rb
+++ b/lib/sequel/adapters/snowflake.rb
@@ -79,6 +79,11 @@ module Sequel
         :values
       end
       private :multi_insert_sql_strategy
+
+      # https://docs.snowflake.com/en/sql-reference/sql/merge
+      def supports_merge?
+        true
+      end
     end
   end
 end

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -67,6 +67,23 @@ describe Sequel::Snowflake::Dataset do
       expect(db[test_table].count).to eq(2)
       expect(db[test_table].select(:n).all).to eq([{ n: 17 }, { n: 18 }])
     end
+
+    it 'can use MERGE' do
+      merge_table = "#{test_table}_MERGE".to_sym
+
+      db.create_table(merge_table, :temp => true) do
+        String :from
+        String :to
+      end
+
+      db[test_table].insert({ str: 'foo', str2: 'foo' })
+      db[merge_table].insert({ from: 'foo', to: 'bar' })
+      db[test_table].merge_using(merge_table, str: :from).merge_update(str2: :to).merge
+
+      expect(db[test_table].select_map(:str2)).to eq(['bar'])
+
+      db.drop_table(merge_table)
+    end
   end
 
   describe '#explain' do


### PR DESCRIPTION
Snowflake supports merge (https://docs.snowflake.com/en/sql-reference/sql/merge) but it has to be explicitly enabled in Sequel or it will be prevented (https://github.com/jeremyevans/sequel/blob/b19622121c6ce9aed79d5b7bfa499db7b431b205/lib/sequel/dataset/sql.rb#L95). This just sets the flag to allow MERGE w/ a spec.