### PR TITLE
Add MERGE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.0 / 2023-10-17
+* Add support for `MERGE` (credit: @benalavi)
+* Add requirement for `sequel` v5.58.0 or newer (to support the new MERGE methods).
+
 ## 2.1.0 / 2022-06-17
 * Add support for `EXPLAIN`.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ be taken down either via the `after(:each)` blocks or when the connection is clo
 
 We have two workflows included in this project:
 
-* Ruby (`ruby.yml`): This runs the specs for this gem against Ruby 2.6, 2.7, and 3.0. Note
+* Ruby (`ruby.yml`): This runs the specs for this gem against Ruby 3.0 and 3.1. Note
 that this requires the secret `SNOWFLAKE_CONN_STR` to be set (see above for example connection string),
 as we need to connect to Snowflake to run tests. These specs will be run for every pull request,
 and is run after every commit to those branches.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An adapter to connect to Snowflake databases using [Sequel](http://sequel.jeremyevans.net/).
 This provides proper types for returned values, as opposed to the ODBC adapter.
 
-[![Ruby](https://github.com/Yesware/sequel-snowflake/actions/workflows/ruby.yml/badge.svg)](https://github.com/Yesware/sequel-snowflake/actions/workflows/ruby.yml)
+[![Ruby](https://github.com/vendasta/sequel-snowflake/actions/workflows/ruby.yml/badge.svg)](https://github.com/vendasta/sequel-snowflake/actions/workflows/ruby.yml)
 
 ## Installation
 
@@ -68,7 +68,7 @@ to authenticate with RubyGems.
 
 ## Contributing
 
-1. Fork it ( https://github.com/Yesware/sequel-snowflake/fork )
+1. Fork it ( https://github.com/vendasta/sequel-snowflake/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/sequel-snowflake/version.rb
+++ b/lib/sequel-snowflake/version.rb
@@ -1,6 +1,6 @@
 module Sequel
   module Snowflake
     # sequel-snowflake version
-    VERSION = "2.1.0"
+    VERSION = "2.2.0"
   end
 end

--- a/lib/sequel/adapters/snowflake.rb
+++ b/lib/sequel/adapters/snowflake.rb
@@ -38,6 +38,11 @@ module Sequel
         self
       end
 
+      # https://docs.snowflake.com/en/sql-reference/sql/merge
+      def supports_merge?
+        true
+      end
+
       # This is similar to the ODBC adapter's Dataset#convert_odbc_value, except for some special casing
       # around Snowflake numerics, which come in through ODBC as Strings instead of Numbers.
       # In those cases, we need to examine the column type as well as the scale,

--- a/lib/sequel/adapters/snowflake.rb
+++ b/lib/sequel/adapters/snowflake.rb
@@ -38,7 +38,9 @@ module Sequel
         self
       end
 
-      # https://docs.snowflake.com/en/sql-reference/sql/merge
+      # Whether the MERGE statement is supported:
+      # https://github.com/jeremyevans/sequel/blob/master/lib/sequel/dataset/features.rb#L129
+      # Snowflake reference: https://docs.snowflake.com/en/sql-reference/sql/merge
       def supports_merge?
         true
       end

--- a/sequel-snowflake.gemspec
+++ b/sequel-snowflake.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_runtime_dependency 'sequel'
+  spec.add_runtime_dependency 'sequel', '>= 5.58.0'
   spec.add_runtime_dependency 'ruby-odbc'
 
   spec.add_development_dependency 'rake'

--- a/sequel-snowflake.gemspec
+++ b/sequel-snowflake.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.summary       = %q{Sequel adapter for Snowflake}
   spec.description   = spec.summary
-  spec.homepage      = "https://github.com/Yesware/sequel-snowflake"
+  spec.homepage      = "https://github.com/vendasta/sequel-snowflake"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -86,6 +86,7 @@ describe Sequel::Snowflake::Dataset do
       end
 
       db[target_table].insert({ str: 'foo', str2: 'foo' })
+      db[target_table].insert({ str: 'baz', str2: 'foo' })
       db[source_table].insert({ from: 'foo', to: 'bar' })
     end
 
@@ -97,7 +98,10 @@ describe Sequel::Snowflake::Dataset do
     it 'can use MERGE' do
       db[target_table].merge_using(source_table, str: :from).merge_update(str2: :to).merge
 
-      expect(db[target_table].select_map(:str2)).to eq(['bar'])
+      expect(db[target_table].select_all.all).to match_array([
+        { str: 'foo', str2: 'bar' },
+        { str: 'baz', str2: 'foo' },
+      ])
     end
   end
 

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -78,16 +78,18 @@ describe Sequel::Snowflake::Dataset do
       db.create_table(target_table, :temp => true) do
         String :str
         String :str2
+        String :str3
       end
 
       db.create_table(source_table, :temp => true) do
         String :from
         String :to
+        String :whomst
       end
 
-      db[target_table].insert({ str: 'foo', str2: 'foo' })
-      db[target_table].insert({ str: 'baz', str2: 'foo' })
-      db[source_table].insert({ from: 'foo', to: 'bar' })
+      db[target_table].insert({ str: 'foo', str2: 'foo', str3: 'phoo' })
+      db[target_table].insert({ str: 'baz', str2: 'foo', str3: 'buzz' })
+      db[source_table].insert({ from: 'foo', to: 'bar', whomst: 'me' })
     end
 
     after(:each) do
@@ -99,8 +101,8 @@ describe Sequel::Snowflake::Dataset do
       db[target_table].merge_using(source_table, str: :from).merge_update(str2: :to).merge
 
       expect(db[target_table].select_all.all).to match_array([
-        { str: 'foo', str2: 'bar' },
-        { str: 'baz', str2: 'foo' },
+        { str: 'foo', str2: 'bar', str3: 'phoo' },
+        { str: 'baz', str2: 'foo', str3: 'buzz' }
       ])
     end
   end

--- a/spec/sequel/adapters/snowflake_spec.rb
+++ b/spec/sequel/adapters/snowflake_spec.rb
@@ -71,33 +71,33 @@ describe Sequel::Snowflake::Dataset do
   end
 
   describe 'MERGE feature' do
-    let(:merge_table_1) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}_1".to_sym }
-    let(:merge_table_2) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}_2".to_sym }
+    let(:target_table) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
+    let(:source_table) { "SEQUEL_SNOWFLAKE_SPECS_#{SecureRandom.hex(10)}".to_sym }
 
     before(:each) do
-      db.create_table(merge_table_1, :temp => true) do
+      db.create_table(target_table, :temp => true) do
         String :str
         String :str2
       end
 
-      db.create_table(merge_table_2, :temp => true) do
+      db.create_table(source_table, :temp => true) do
         String :from
         String :to
       end
 
-      db[merge_table_1].insert({ str: 'foo', str2: 'foo' })
-      db[merge_table_2].insert({ from: 'foo', to: 'bar' })
+      db[target_table].insert({ str: 'foo', str2: 'foo' })
+      db[source_table].insert({ from: 'foo', to: 'bar' })
     end
 
     after(:each) do
-      db.drop_table(merge_table_1)
-      db.drop_table(merge_table_2)
+      db.drop_table(target_table)
+      db.drop_table(source_table)
     end
 
     it 'can use MERGE' do
-      db[merge_table_1].merge_using(merge_table_2, str: :from).merge_update(str2: :to).merge
+      db[target_table].merge_using(source_table, str: :from).merge_update(str2: :to).merge
 
-      expect(db[merge_table_1].select_map(:str2)).to eq(['bar'])
+      expect(db[target_table].select_map(:str2)).to eq(['bar'])
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/vendasta/sequel-snowflake/pull/13

Included CHANGELOG, version updates, and a version restriction on `sequel` as MERGE requires a newer method exposed in the `sequel` gem.